### PR TITLE
Add power operation to calculator functionality

### DIFF
--- a/api/controller.js
+++ b/api/controller.js
@@ -16,6 +16,7 @@ exports.calculate = function(req, res) {
     'subtract': function(a, b) { return a - b },
     'multiply': function(a, b) { return a * b },
     'divide':   function(a, b) { return a / b },
+    'power':    function(a, b) { return Math.pow(Number(a), Number(b)) }
   };
 
   if (!req.query.operation) {


### PR DESCRIPTION
This pull request introduces a new operation to the `calculate` function in `api/controller.js`. The most important change is the addition of a `power` operation that raises one number to the power of another.

Enhancements to the `calculate` function:

* [`api/controller.js`](diffhunk://#diff-401952c3eed6d886c8b542cd80766fc87baba4f1561c1c0373363350053a12caR19): Added a new `'power'` operation to the `operations` object, which calculates the result of raising one number to the power of another using `Math.pow`.