### PR TITLE
Add power operation handling in calculate function

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -33,6 +33,9 @@ function calculate(operand1, operand2, operation) {
         case '/':
             uri += "?operation=divide";
             break;
+        case '^':
+            uri += "?operation=power";
+            break;
         default:
             setError();
             return;


### PR DESCRIPTION
This pull request introduces a small enhancement to the `calculate` function in `public/client.js`. It adds support for the power operation (`^`) by appending the appropriate query parameter to the URI.

* [`public/client.js`](diffhunk://#diff-3c1c78fbccf841ecda30fc632b85abd36bd1a172918d5cad21fcbfea3f74a321R36-R38): Added a new case for the `^` operator in the `calculate` function to handle power operations.