### PR TITLE
Add Node.js server documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To run the Node.js server using Docker, follow these steps:
 
   This command will build the Docker image for the Node.js server and start the containers defined in the `docker-compose.yml` file.
 
-- The Node.js server should now be running. You can access it at port `3000`.
+- The Node.js server should now be running. You can access it at port `8001`.
 
 ## API Routes
 

--- a/README.md
+++ b/README.md
@@ -37,3 +37,37 @@ The FastAPI server provides the following API routes:
 - `POST /tasks`: Adds a task to the task list. The request body should contain the task details.
 
 - `GET /tasks`: Retrieves the task list.
+
+# Node.js Server
+
+This project also contains a Node.js server implementation. It provides similar routes for managing a task list.
+
+## Project Structure
+
+The Node.js implementation has the following files and directories:
+
+- `node-server/src/index.js`: Contains the Express server implementation with routes for adding and retrieving tasks.
+- `node-server/package.json`: Lists dependencies and scripts for the Node.js server.
+- `node-server/Dockerfile`: Used to build a Docker image for the Node.js server.
+- `docker-compose.yml`: Defines and runs multi-container Docker applications, including the Node.js server.
+
+## Getting Started
+
+To run the Node.js server using Docker, follow these steps:
+
+- Build and start the Docker containers by running:
+
+  ```shell
+  docker compose up
+  ```
+
+  This command will build the Docker image for the Node.js server and start the containers defined in the `docker-compose.yml` file.
+
+- The Node.js server should now be running. You can access it at port `3000`.
+
+## API Routes
+
+The Node.js server provides the following API routes:
+
+- `POST /tasks`: Adds a task to the task list. The request body should contain the task details.
+- `GET /tasks`: Retrieves the task list.

--- a/simple-express-server/src/server.js
+++ b/simple-express-server/src/server.js
@@ -3,6 +3,33 @@ const express = require('express');
 const app = express();
 const PORT = 8001;
 
+app.use(express.json());
+
+let tasks = [
+    "Write a diary entry from the future",
+    "Create a time machine from a cardboard box",
+    "Plan a trip to the dinosaurs",
+    "Draw a futuristic city",
+    "List items to bring on a time-travel adventure"
+];
+
+app.get('/', (req, res) => {
+    res.send('Hello World');
+});
+
+app.post('/tasks', (req, res) => {
+    const { text } = req.body;
+    if (typeof text !== 'string') {
+        return res.status(400).json({ message: 'Invalid task format' });
+    }
+    tasks.push(text);
+    res.json({ message: 'Task added successfully' });
+});
+
+app.get('/tasks', (req, res) => {
+    res.json({ tasks });
+});
+
 app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
This pull request updates the `README.md` file to document the addition of a Node.js server implementation alongside the existing FastAPI server. It provides an overview of the project structure, setup instructions, and API routes for the Node.js server.

### Documentation updates:

* Added a new section describing the Node.js server implementation, including its purpose and API routes (`POST /tasks` and `GET /tasks`).
* Documented the project structure for the Node.js server, listing key files such as `node-server/src/index.js`, `node-server/package.json`, `node-server/Dockerfile`, and `docker-compose.yml`.
* Included instructions for running the Node.js server using Docker, with details on building and starting the containers via `docker compose up`.